### PR TITLE
Add Thread ts compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,9 @@ controller.hears(/give\s+<@([A-z|0-9]+)>\s+([0-9]+)(?:gp)?(?:\s+for\s+(.+))?/i, 
     ts,
     channel
   } = message
-
+  if (message.thread_ts) {
+    ts = message.thread_ts;
+  }
   if (message.type == "bot_message" && !(data.bots.includes(user))) return
 
   console.log(`Processing give request from ${user}`)


### PR DESCRIPTION
Basically if there is a `thread_ts` value in the message, it will replace it with the `ts` val so that we can reply to threaded messages. so that it is no more the id of the message, but the parent ts.

more at https://api.slack.com/docs/message-threading