### PR TITLE
Reply private in public channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,7 +517,7 @@ controller.on('slash_command', (bot, message) => {
             user == target
               ? `Ah yes, <@${target}> (${target}). You have ${balance}gp in your account, sirrah.`
               : `Ah yes, <@${target}> (${target})—they have ${balance}gp.`;
-          bot.replyPublicDelayed(message, {
+          bot.replyPrivateDelayed(message, {
             blocks: [
               {
                 type: 'section',


### PR DESCRIPTION
Banker frequently replies publicly in public channels with the balance of people who request a balance. Lots of people seem to be requesting balances, and it's become a nuisance to me. I think that banker should send an ephemeral message when the command is run in a public channel.