### PR TITLE
Check for bot first, check for DM later

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,7 +249,14 @@ var transferJob = (
 
         var isPrivate = false;
 
-        if (channelType == 'im') {
+        if (data.bots.includes(target)) {
+          // send clean, splittable data string
+          bot.say({
+            user: '@' + target,
+            channel: '@' + target,
+            text: `$$$ | <@${user}> | ${amount} | ${replyNote} | ${channelid} | ${ts}`,
+          });
+        } else if (channelType == 'im') {
           bot.say({
             user: '@' + target,
             channel: '@' + target,
@@ -257,14 +264,7 @@ var transferJob = (
           });
 
           isPrivate = true;
-        } else if (data.bots.includes(target)) {
-          // send clean, splittable data string
-          bot.say({
-            user: '@' + target,
-            channel: '@' + target,
-            text: `$$$ | <@${user}> | ${amount} | ${replyNote} | ${channelid} | ${ts}`,
-          });
-        }
+        } 
 
         logTransaction(user, target, amount, note, true, '', isPrivate);
       });


### PR DESCRIPTION
Old method: When payment,
- Check if payment channel is DM, if yes, send notif
- Otherwise, check if recipient is bot, if yes, send formatted notif

This breaks when bots are paid in DMs, since they get the unformatted notification. Check if the recipient is a bot first